### PR TITLE
Add the required urllib3 library to the requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 python-telegram-bot==13.7
-python-dotenv==1.0.0 
+python-dotenv==1.0.0
+urllib3==1.26.15


### PR DESCRIPTION
The server throughs
`ModuleNotFoundError: No module named 'urllib3'` or
`ModuleNotFoundError: No module named 'urllib3.contrib.appengine'`
if this library is not installed